### PR TITLE
Include option for active block highlight

### DIFF
--- a/roam-research-dark.user.css
+++ b/roam-research-dark.user.css
@@ -87,6 +87,7 @@
 @advanced   checkbox  using-split-screen        "Use split-screen layout"       0
 @advanced   checkbox  using-clickup             "Using embedded in ClickUp?"    0
 @advanced   checkbox  using-breathing           "Use breathing exercise loader" 0
+@advanced   checkbox  using-block-highlight     "Use active block highlight"    0
 @advanced   color     color-breathing-from      "Breathing Colour 1"            #1F7A8C
 @advanced   color     color-breathing-to        "Breathing Colour 2"            #BFDBF7
 @advanced   color     color-heading-2           "H2 Colour"                     #b9b9b9
@@ -310,6 +311,19 @@
             }
         }
     }
+    
+    /* highlight current block */
+    if using-block-highlight {
+        .rm-block-input {
+            background: rgba(10,10,10,0.2) !important;
+            padding-left: 1em;
+            padding-right: 1em;
+            padding-top: 0.5em;
+            padding-bottom: 0.5em;
+            border-radius: 5px;
+        }
+    }
+
 
     /* more subtle logo */
     #roam-sidebar-logo img {


### PR DESCRIPTION
Highlight the block currently being edited by darkening the background and adding some padding for emphasis and whitespace.

This is just something I find pleasing while working on larger documents and helps me find my place when scrolling around. Feel free to adjust/discard etc

(thanks for the great theme!)